### PR TITLE
add new metascope for Svelte Components

### DIFF
--- a/Svelte.sublime-syntax
+++ b/Svelte.sublime-syntax
@@ -37,6 +37,11 @@ variables:
       button|datalist|input|label|legend|meter|optgroup|option|output|progress|select|template|textarea
     ){{tag_name_break}}
 
+  component_tag_name: |-
+    (?x:
+      [A-Z]+[a-zA-Z]+|[a-zA-Z]+\:[a-zA-Z]+
+    ){{tag_name_break}}
+
   javascript_mime_type: |-
     (?ix:
       # https://mimesniff.spec.whatwg.org/#javascript-mime-type
@@ -729,6 +734,14 @@ contexts:
         2: entity.name.tag.inline.any.html
       push:
         - meta_scope: meta.tag.inline.any.html
+        - include: tag-end-maybe-self-closing
+        - include: tag-attributes
+    - match: (</?)({{component_tag_name}})
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.inline.form.html
+      push:
+        - meta_scope: meta.tag.component.form.html
         - include: tag-end-maybe-self-closing
         - include: tag-attributes
     - match: (</?)({{form_tag_name}})


### PR DESCRIPTION
Add meta.tag.component.form.html to elements that start with capital letters, and also <tag:property> style tags.

![image](https://user-images.githubusercontent.com/30809170/129399267-c8dbd7ea-c694-48b5-801d-9a259f7a7a1f.png)

![image](https://user-images.githubusercontent.com/30809170/129399451-ace1658f-4614-4acf-b4f7-a837ddd58d84.png)
