### PR TITLE
Make sure attributes with inline JavaScript are correctly closed

### DIFF
--- a/Svelte.sublime-syntax
+++ b/Svelte.sublime-syntax
@@ -574,7 +574,11 @@ contexts:
     - match: \}
       scope: punctuation.section.embedded.end.svelte
       pop: true
-    - include: Packages/JavaScript/JavaScript.sublime-syntax
+    - match: ''
+      push: scope:source.js
+      with_prototype:
+        - match: (?=\}[^\}])
+          pop: true
 
   script-lang-decider-lang:
     - match: (?i)(?=(?:ts|typescript)(?!{unquoted_attribute_value})|\'(?:ts|typescript)\'|"(?:ts|typescript)")


### PR DESCRIPTION
Fixes corneliusio/svelte-sublime#16
Fixes corneliusio/svelte-sublime#17

There may be a better way to fix this, but this seems to work for me. It would be nice to have some syntax tests in this repo to be able to verify that things work in more unusual use cases.