### PR TITLE
Add style:property and @const

### DIFF
--- a/Svelte.sublime-syntax
+++ b/Svelte.sublime-syntax
@@ -554,7 +554,7 @@ contexts:
         - include: svelte-attribute-modifiers
 
   svelte-attributes-string:
-    - match: (?i)\b(on|bind|class)(:)([A-z0-9_-]+)\b
+    - match: (?i)\b(on|bind|class|style)(:)([A-z0-9_-]+)\b
       scope: entity.other.attribute-name.svelte
       captures:
         1: support.function.svelte
@@ -581,7 +581,7 @@ contexts:
         - include: script-close-tag
 
   control:
-    - match: \{@(html|debug)
+    - match: \{@(html|debug|const)
       scope: punctuation.section.embedded.begin.svelte
       push: embed-scope
 

--- a/Svelte.sublime-syntax.yaml-macros
+++ b/Svelte.sublime-syntax.yaml-macros
@@ -38,7 +38,7 @@ contexts: !merge
     - include: set-interpolation
 
   svelte-attributes-string:
-    - match: !word (on|bind|class)(:)([A-z0-9_-]+)
+    - match: !word (on|bind|class|style)(:)([A-z0-9_-]+)
       scope: entity.other.attribute-name.svelte
       captures:
         1: support.function.svelte
@@ -76,7 +76,7 @@ contexts: !merge
         2: support.constant.svelte
 
   control:
-    - match: \{@(html|debug)
+    - match: \{@(html|debug|const)
       scope: punctuation.section.embedded.begin.svelte
       push: embed-scope
 


### PR DESCRIPTION
Resolve #23 

*I don't know, how to do [this](https://svelte.dev/docs#template-syntax-const):*

> `{@const}` is only allowed as direct child of `{#each}`, `{:then}`, `{:catch}`, `<Component />` or `<svelte:fragment />`.