### PR TITLE
Fix CI syntax tests

### DIFF
--- a/.github/workflows/ci-syntax-tests.yml
+++ b/.github/workflows/ci-syntax-tests.yml
@@ -47,6 +47,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: ${{ env.package_name }}
+          path: Svelte
       - name: Checkout Less (dependency)
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
This commit explicitly specifies package name to checkout Svelte package as to ensure package is loaded in syntax test environment with correct name.

Hopefully fixing failing CI tests on master.