### PR TITLE
Fix interpolated inline styles

### DIFF
--- a/Embeddings/CSS (for Svelte double-quoted).sublime-syntax
+++ b/Embeddings/CSS (for Svelte double-quoted).sublime-syntax
@@ -1,0 +1,39 @@
+%YAML 1.2
+---
+# A special syntax definition to drive double quoted inline style attributes
+# with {...} interpolation support
+scope: source.css.embedded.svelte.double-quoted
+version: 2
+hidden: true
+
+extends: Packages/CSS/CSS.sublime-syntax
+
+variables:
+  ident_start: (?:{{nmstart}}|{)
+
+contexts:
+  main:
+    - include: rule-list-body
+
+  prototype:
+    - meta_prepend: true
+    - include: Svelte.sublime-syntax#svelte-blocks
+
+  string-content:
+    - meta_prepend: true
+    - include: Svelte.sublime-syntax#svelte-interpolations
+
+  quoted-strings:
+    - meta_prepend: true
+    - match: (?=\")
+      pop: 1
+
+  quoted-string:
+    - meta_prepend: true
+    - match: (?=\")
+      pop: 1
+
+  quoted-urls:
+    - meta_prepend: true
+    - match: (?=\")
+      pop: 1

--- a/Embeddings/CSS (for Svelte single-quoted).sublime-syntax
+++ b/Embeddings/CSS (for Svelte single-quoted).sublime-syntax
@@ -1,0 +1,39 @@
+%YAML 1.2
+---
+# A special syntax definition to drive single quoted inline style attributes
+# with {...} interpolation support
+scope: source.css.embedded.svelte.single-quoted
+version: 2
+hidden: true
+
+extends: Packages/CSS/CSS.sublime-syntax
+
+variables:
+  ident_start: (?:{{nmstart}}|{)
+
+contexts:
+  main:
+    - include: rule-list-body
+
+  prototype:
+    - meta_prepend: true
+    - include: Svelte.sublime-syntax#svelte-blocks
+
+  string-content:
+    - meta_prepend: true
+    - include: Svelte.sublime-syntax#svelte-interpolations
+
+  quoted-strings:
+    - meta_prepend: true
+    - match: (?=\')
+      pop: 1
+
+  quoted-string:
+    - meta_prepend: true
+    - match: (?=\')
+      pop: 1
+
+  quoted-urls:
+    - meta_prepend: true
+    - match: (?=\')
+      pop: 1

--- a/Svelte.sublime-syntax
+++ b/Svelte.sublime-syntax
@@ -422,6 +422,36 @@ contexts:
         3: source.stylus.embedded.html
         4: comment.block.html punctuation.definition.comment.end.html
 
+###[ STYLE ATTRIBUTES ]########################################################
+
+  tag-style-attribute-value:
+    - meta_include_prototype: false
+    - match: \"
+      scope: meta.string.html string.quoted.double.html punctuation.definition.string.begin.html
+      set: tag-style-attribute-double-quoted-value
+    - match: \'
+      scope: meta.string.html string.quoted.single.html punctuation.definition.string.begin.html
+      set: tag-style-attribute-single-quoted-value
+    - include: else-pop
+
+  tag-style-attribute-double-quoted-value:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.html meta.interpolation.html source.css.embedded.html
+    - match: \"
+      scope: meta.string.html string.quoted.double.html punctuation.definition.string.end.html
+      pop: 1
+    - include: scope:source.css.embedded.svelte.double-quoted
+      apply_prototype: true
+
+  tag-style-attribute-single-quoted-value:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.html meta.interpolation.html source.css.embedded.html
+    - match: \'
+      scope: meta.string.html string.quoted.single.html punctuation.definition.string.end.html
+      pop: 1
+    - include: scope:source.css.embedded.svelte.single-quoted
+      apply_prototype: true
+
 ###[ SVELTE COMPONENTS ]#######################################################
 
   svelte-components:
@@ -487,23 +517,32 @@ contexts:
     - include: else-pop
 
   svelte-style-attribute-value:
+    - meta_include_prototype: false
     - match: \"
       scope: meta.string.html string.quoted.double.html punctuation.definition.string.begin.html
-      embed: scope:source.css#property-value-content
-      embed_scope: meta.string.html meta.interpolation.html source.css.embedded.html
-      escape: \"
-      escape_captures:
-        0: meta.attribute-with-value.style.html meta.string.html string.quoted.double.html punctuation.definition.string.end.html
-      pop: 1
+      set: svelte-style-attribute-double-quoted-value
     - match: \'
       scope: meta.string.html string.quoted.single.html punctuation.definition.string.begin.html
-      embed: scope:source.css#property-value-content
-      embed_scope: meta.string.html meta.interpolation.html source.css.embedded.html
-      escape: \'
-      escape_captures:
-        0: meta.attribute-with-value.style.html meta.string.html string.quoted.single.html punctuation.definition.string.end.html
-      pop: 1
+      set: svelte-style-attribute-single-quoted-value
     - include: else-pop
+
+  svelte-style-attribute-double-quoted-value:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.html meta.interpolation.html source.css.embedded.html meta.property-value.css
+    - match: \"
+      scope: meta.string.html string.quoted.double.html punctuation.definition.string.end.html
+      pop: 1
+    - include: scope:source.css.embedded.svelte.double-quoted#property-value-content
+      apply_prototype: true
+
+  svelte-style-attribute-single-quoted-value:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.html meta.interpolation.html source.css.embedded.html meta.property-value.css
+    - match: \'
+      scope: meta.string.html string.quoted.single.html punctuation.definition.string.end.html
+      pop: 1
+    - include: scope:source.css.embedded.svelte.single-quoted#property-value-content
+      apply_prototype: true
 
   svelte-variable-attributes:
     - match: ((?i:in|out|transition|animate|use))(:)({{svelte_attribute_name}})

--- a/Svelte.sublime-syntax
+++ b/Svelte.sublime-syntax
@@ -435,7 +435,15 @@ contexts:
   svelte-component-body:
     - meta_scope: meta.tag.component.html
     - include: tag-end-maybe-self-closing
-    - include: tag-attributes
+    # all tag-attributes (except `event` and `style`)
+    - include: svelte-string-attributes
+    - include: svelte-storage-attributes
+    - include: svelte-style-attributes
+    - include: svelte-variable-attributes
+    - include: tag-id-attribute
+    - include: tag-class-attribute
+    - include: tag-href-attribute
+    - include: tag-generic-attribute
 
 ###[ SVELTE TAG ATTRIBUTES ]###################################################
 

--- a/tests/syntax_test_scope.svelte
+++ b/tests/syntax_test_scope.svelte
@@ -172,6 +172,21 @@
 /*                                           ^ string.quoted.single.html punctuation.definition.string.end.html */
 /*                                             ^^ punctuation.definition.tag.end.html */
 
+<button style="-moz-{prop['name']}: '{color["key"]}'"></button>
+/*^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag */
+/*      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.style.html */
+/*            ^ meta.string.html string.quoted.double.html punctuation.definition.string.begin.html */
+/*             ^^^^^ meta.string.html meta.interpolation.html source.css.embedded.html - meta.embedded.block.svelte */
+/*                  ^^^^^^^^^^^^^^ meta.string.html meta.interpolation.html source.css.embedded.html meta.embedded.block.svelte */
+/*                  ^ punctuation.section.embedded.begin.svelte */
+/*                   ^^^^^^^^^^^^ source.js.embedded.svelte */
+/*                               ^ punctuation.section.embedded.end.svelte */
+/*                                ^^^ meta.string.html meta.interpolation.html source.css.embedded.html - meta.embedded.block.svelte */
+/*                                   ^^^^^^^^^^^^^^ meta.string.html meta.interpolation.html source.css.embedded.html meta.embedded.block.svelte */
+/*                                                 ^ meta.string.html meta.interpolation.html source.css.embedded.html - meta.embedded.block.svelte */
+/*                                                  ^ meta.string.html string.quoted.double.html punctuation.definition.string.end.html */
+/*                                                   ^ punctuation.definition.tag.end.html */
+
 
 ###[ COMPONENTS ]##############################################################
 

--- a/tests/syntax_test_scope.svelte
+++ b/tests/syntax_test_scope.svelte
@@ -157,6 +157,22 @@
 /*                                             ^^^^^^^^^^^ meta.string.html meta.interpolation.html source.css.embedded.html meta.property-value.css meta.function-call.arguments.css meta.group.css
 /*                                                        ^ meta.string.html string.quoted.double.html punctuation.definition.string.end.html
 
+<CopyButton style='flex px-4 {dynamicClasses}' />
+/*^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.template.svelte meta.tag.component.html */
+/*^^^^^^^^^ entity.name.tag.component.svelte */
+/*          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.html */
+/*          ^^^^^ entity.other.attribute-name.html */
+/*               ^ punctuation.separator.key-value.html */
+/*                ^^^^^^^^^^^ meta.string.html string.quoted.single.html */
+/*                ^ punctuation.definition.string.begin.html */
+/*                           ^^^^^^^^^^^^^^^^ meta.string.html meta.embedded.block.svelte */
+/*                           ^ punctuation.section.embedded.begin.svelte */
+/*                            ^^^^^^^^^^^^^^ source.js.embedded.svelte variable.other.readwrite.js */
+/*                                          ^ punctuation.section.embedded.end.svelte */
+/*                                           ^ string.quoted.single.html punctuation.definition.string.end.html */
+/*                                             ^^ punctuation.definition.tag.end.html */
+
+
 ###[ COMPONENTS ]##############################################################
 
     <MyComponent {...}/>


### PR DESCRIPTION
Fixes #38

This PR excludes `tag-event-attribute` and `tag-style-attribute` contexts from Svelte components as both haven't default HTML meaning and embedded syntax definitions might cause conflicts.