### PR TITLE
Enhance support for lang/type attributes

### DIFF
--- a/.github/workflows/ci-syntax-tests.yml
+++ b/.github/workflows/ci-syntax-tests.yml
@@ -64,10 +64,30 @@ jobs:
           repository: SublimeText/Sass
           ref: ${{ matrix.sass_ref }}
           path: Sass
+      - name: Prepare dummy syntaxes
+        run: |
+          scopes=(
+              source.coffee
+              source.livescript
+              source.postcss
+              source.sss
+              source.stylus
+          )
+          mkdir -vp "Dummy"
+          for scope in ${scopes[@]}; do
+          cat << SYNTAX > "Dummy/$scope.sublime-syntax"
+          %YAML 1.2
+          ---
+          scope: $scope
+
+          contexts:
+              main: []
+          SYNTAX
+          done
       - uses: SublimeText/syntax-test-action@v2
         with:
           build: ${{ matrix.build }}
           package_name: Svelte
           package_root: Svelte
           default_packages: ${{ matrix.default_packages }}
-          additional_packages: Less,Sass
+          additional_packages: Dummy,Less,Sass

--- a/Completions/Script Lang Values.sublime-completions
+++ b/Completions/Script Lang Values.sublime-completions
@@ -1,0 +1,45 @@
+{
+	"scope": "text.html.svelte meta.tag.script meta.attribute-with-value.lang",
+	"completions": [
+		{
+			"trigger": "babel",
+			"kind": ["type", "t", "Language Type"],
+			"details": "Babel"
+		},
+		{
+			"trigger": "coffee",
+			"kind": ["type", "t", "Language Type"],
+			"details": "CoffeeScript"
+		},
+		{
+			"trigger": "coffeescript",
+			"kind": ["type", "t", "Language Type"],
+			"details": "CoffeeScript"
+		},
+		{
+			"trigger": "livescript",
+			"kind": ["type", "t", "Language Type"],
+			"details": "LiveScript"
+		},
+		{
+			"trigger": "js",
+			"kind": ["type", "t", "Language Type"],
+			"details": "JavaScript"
+		},
+		{
+			"trigger": "javascript",
+			"kind": ["type", "t", "Language Type"],
+			"details": "JavaScript"
+		},
+		{
+			"trigger": "ts",
+			"kind": ["type", "t", "Language Type"],
+			"details": "TypeScript"
+		},
+		{
+			"trigger": "typescript",
+			"kind": ["type", "t", "Language Type"],
+			"details": "TypeScript"
+		},
+	]
+}

--- a/Completions/Script Type Values.sublime-completions
+++ b/Completions/Script Type Values.sublime-completions
@@ -1,0 +1,58 @@
+{
+	"scope": "text.html.svelte meta.tag.script meta.attribute-with-value.type",
+	"completions": [
+
+		// Note: JavaScript mime type is provided out of the box as of ST4184+
+
+		{
+			"trigger": "application/babel",
+			"kind": ["type", "t", "Language Type"],
+			"details": "Babel"
+		},
+		{
+			"trigger": "application/coffee",
+			"kind": ["type", "t", "Language Type"],
+			"details": "CoffeeScript"
+		},
+		{
+			"trigger": "application/coffeescript",
+			"kind": ["type", "t", "Language Type"],
+			"details": "CoffeeScript"
+		},
+		{
+			"trigger": "application/livescript",
+			"kind": ["type", "t", "Language Type"],
+			"details": "LiveScript"
+		},
+		{
+			"trigger": "application/typescript",
+			"kind": ["type", "t", "Language Type"],
+			"details": "TypeScript"
+		},
+		{
+			"trigger": "text/babel",
+			"kind": ["type", "t", "Language Type"],
+			"details": "Babel"
+		},
+		{
+			"trigger": "text/coffee",
+			"kind": ["type", "t", "Language Type"],
+			"details": "CoffeeScript"
+		},
+		{
+			"trigger": "text/coffeescript",
+			"kind": ["type", "t", "Language Type"],
+			"details": "CoffeeScript"
+		},
+		{
+			"trigger": "text/livescript",
+			"kind": ["type", "t", "Language Type"],
+			"details": "LiveScript"
+		},
+		{
+			"trigger": "text/typescript",
+			"kind": ["type", "t", "Language Type"],
+			"details": "TypeScript"
+		},
+	]
+}

--- a/Completions/Style Lang Values.sublime-completions
+++ b/Completions/Style Lang Values.sublime-completions
@@ -1,0 +1,35 @@
+{
+	"scope": "text.html.svelte meta.tag.style meta.attribute-with-value.lang",
+	"completions": [
+		{
+			"trigger": "css",
+			"kind": ["type", "t", "Language Type"],
+			"details": "CSS"
+		},
+		{
+			"trigger": "less",
+			"kind": ["type", "t", "Language Type"],
+			"details": "Less"
+		},
+		{
+			"trigger": "postcss",
+			"kind": ["type", "t", "Language Type"],
+			"details": "PostCSS"
+		},
+		{
+			"trigger": "sass",
+			"kind": ["type", "t", "Language Type"],
+			"details": "Sass"
+		},
+		{
+			"trigger": "scss",
+			"kind": ["type", "t", "Language Type"],
+			"details": "SCSS"
+		},
+		{
+			"trigger": "stylus",
+			"kind": ["type", "t", "Language Type"],
+			"details": "Stylus"
+		},
+	]
+}

--- a/Completions/Style Type Values.sublime-completions
+++ b/Completions/Style Type Values.sublime-completions
@@ -1,0 +1,35 @@
+{
+	"scope": "text.html.svelte meta.tag.style meta.attribute-with-value.type",
+	"completions": [
+		{
+			"trigger": "text/css",
+			"kind": ["type", "t", "Language Type"],
+			"details": "CSS"
+		},
+		{
+			"trigger": "text/less",
+			"kind": ["type", "t", "Language Type"],
+			"details": "Less"
+		},
+		{
+			"trigger": "text/postcss",
+			"kind": ["type", "t", "Language Type"],
+			"details": "PostCSS"
+		},
+		{
+			"trigger": "text/sass",
+			"kind": ["type", "t", "Language Type"],
+			"details": "Sass"
+		},
+		{
+			"trigger": "text/scss",
+			"kind": ["type", "t", "Language Type"],
+			"details": "SCSS"
+		},
+		{
+			"trigger": "text/stylus",
+			"kind": ["type", "t", "Language Type"],
+			"details": "Stylus"
+		},
+	]
+}

--- a/Svelte.sublime-syntax
+++ b/Svelte.sublime-syntax
@@ -65,7 +65,7 @@ contexts:
     - include: script-lang-attribute
 
   script-lang-attribute:
-    - match: (?i:lang){{attribute_name_break}}
+    - match: (?i:lang(?:uage)?){{attribute_name_break}}
       scope: meta.attribute-with-value.html entity.other.attribute-name.html
       set: script-lang-attribute-assignment
 
@@ -236,7 +236,7 @@ contexts:
     - include: style-lang-attribute
 
   style-lang-attribute:
-    - match: (?i:lang){{attribute_name_break}}
+    - match: (?i:lang(?:uage)?){{attribute_name_break}}
       scope: meta.attribute-with-value.html entity.other.attribute-name.html
       set: style-lang-attribute-assignment
 

--- a/Svelte.sublime-syntax
+++ b/Svelte.sublime-syntax
@@ -66,11 +66,11 @@ contexts:
 
   script-lang-attribute:
     - match: (?i:lang(?:uage)?){{attribute_name_break}}
-      scope: meta.attribute-with-value.html entity.other.attribute-name.html
+      scope: meta.attribute-with-value.lang.html entity.other.attribute-name.html
       set: script-lang-attribute-assignment
 
   script-lang-attribute-assignment:
-    - meta_content_scope: meta.tag.script.begin.html meta.attribute-with-value.html
+    - meta_content_scope: meta.tag.script.begin.html meta.attribute-with-value.lang.html
     - match: =
       scope: punctuation.separator.key-value.html
       set: script-lang-attribute-value
@@ -79,39 +79,39 @@ contexts:
 
   script-lang-attribute-value:
     - meta_include_prototype: false
-    - meta_scope: meta.tag.script.begin.html meta.attribute-with-value.html
+    - meta_scope: meta.tag.script.begin.html meta.attribute-with-value.lang.html
     - include: script-lang-decider
 
   script-lang-decider:
     - match: (?i)(?=babel{{unquoted_attribute_break}}|'babel'|"babel")
       set:
         - script-babel
-        - tag-generic-attribute-meta
+        - tag-lang-attribute-meta
         - tag-generic-attribute-value
     - match: (?i)(?=coffee(?:script)?{{unquoted_attribute_break}}|'coffee(?:script)?'|"coffee(?:script)?")
       set:
         - script-coffeescript
-        - tag-generic-attribute-meta
+        - tag-lang-attribute-meta
         - tag-generic-attribute-value
     - match: (?i)(?=livescript{{unquoted_attribute_break}}|'livescript'|"livescript")
       set:
         - script-livescript
-        - tag-generic-attribute-meta
+        - tag-lang-attribute-meta
         - tag-generic-attribute-value
     - match: (?i)(?=(?:js|javascript){{unquoted_attribute_break}}|'(?:js|javascript)'|"(?:js|javascript)")
       set:
         - script-javascript
-        - tag-generic-attribute-meta
+        - tag-lang-attribute-meta
         - tag-generic-attribute-value
     - match: (?i)(?=(?:ts|typescript){{unquoted_attribute_break}}|'(?:ts|typescript)'|"(?:ts|typescript)")
       set:
         - script-typescript
-        - tag-generic-attribute-meta
+        - tag-lang-attribute-meta
         - tag-generic-attribute-value
     - match: (?=\S)
       set:
         - script-javascript
-        - tag-generic-attribute-meta
+        - tag-lang-attribute-meta
         - tag-generic-attribute-value
 
   script-type-decider:
@@ -119,22 +119,22 @@ contexts:
     - match: (?i)(?={{babel_mime_type}}{{unquoted_attribute_break}}|'{{babel_mime_type}}'|"{{babel_mime_type}}")
       set:
         - script-babel
-        - tag-generic-attribute-meta
+        - tag-type-attribute-meta
         - tag-generic-attribute-value
     - match: (?i)(?={{coffeescript_mime_type}}{{unquoted_attribute_break}}|'{{coffeescript_mime_type}}'|"{{coffeescript_mime_type}}")
       set:
         - script-coffeescript
-        - tag-generic-attribute-meta
+        - tag-type-attribute-meta
         - tag-generic-attribute-value
     - match: (?i)(?={{livescript_mime_type}}{{unquoted_attribute_break}}|'{{livescript_mime_type}}'|"{{livescript_mime_type}}")
       set:
         - script-livescript
-        - tag-generic-attribute-meta
+        - tag-type-attribute-meta
         - tag-generic-attribute-value
     - match: (?i)(?={{typescript_mime_type}}{{unquoted_attribute_break}}|'{{typescript_mime_type}}'|"{{typescript_mime_type}}")
       set:
         - script-typescript
-        - tag-generic-attribute-meta
+        - tag-type-attribute-meta
         - tag-generic-attribute-value
 
   script-babel:
@@ -237,11 +237,11 @@ contexts:
 
   style-lang-attribute:
     - match: (?i:lang(?:uage)?){{attribute_name_break}}
-      scope: meta.attribute-with-value.html entity.other.attribute-name.html
+      scope: meta.attribute-with-value.lang.html entity.other.attribute-name.html
       set: style-lang-attribute-assignment
 
   style-lang-attribute-assignment:
-    - meta_content_scope: meta.tag.style.begin.html meta.attribute-with-value.html
+    - meta_content_scope: meta.tag.style.begin.html meta.attribute-with-value.lang.html
     - match: =
       scope: punctuation.separator.key-value.html
       set: style-lang-attribute-value
@@ -250,71 +250,71 @@ contexts:
 
   style-lang-attribute-value:
     - meta_include_prototype: false
-    - meta_scope: meta.tag.style.begin.html meta.attribute-with-value.html
+    - meta_scope: meta.tag.style.begin.html meta.attribute-with-value.lang.html
     - include: style-lang-decider
 
   style-lang-decider:
     - match: (?i)(?=postcss{{unquoted_attribute_break}}|'postcss'|"postcss")
       set:
         - style-postcss
-        - tag-generic-attribute-meta
+        - tag-lang-attribute-meta
         - tag-generic-attribute-value
     - match: (?i)(?=less{{unquoted_attribute_break}}|'less'|"less")
       set:
         - style-less
-        - tag-generic-attribute-meta
+        - tag-lang-attribute-meta
         - tag-generic-attribute-value
     - match: (?i)(?=sass{{unquoted_attribute_break}}|'sass'|"sass")
       set:
         - style-sass
-        - tag-generic-attribute-meta
+        - tag-lang-attribute-meta
         - tag-generic-attribute-value
     - match: (?i)(?=scss{{unquoted_attribute_break}}|'scss'|"scss")
       set:
         - style-scss
-        - tag-generic-attribute-meta
+        - tag-lang-attribute-meta
         - tag-generic-attribute-value
     - match: (?i)(?=stylus{{unquoted_attribute_break}}|'stylus'|"stylus")
       set:
         - style-stylus
-        - tag-generic-attribute-meta
+        - tag-lang-attribute-meta
         - tag-generic-attribute-value
     - match: (?=\S)
       set:
         - style-css
-        - tag-generic-attribute-meta
+        - tag-lang-attribute-meta
         - tag-generic-attribute-value
 
   style-type-decider:
     - match: (?i)(?=text/postcss{{unquoted_attribute_break}}|'text/postcss'|"text/postcss")
       set:
         - style-postcss
-        - tag-generic-attribute-meta
+        - tag-type-attribute-meta
         - tag-generic-attribute-value
     - match: (?i)(?=text/less{{unquoted_attribute_break}}|'text/less'|"text/less")
       set:
         - style-less
-        - tag-generic-attribute-meta
+        - tag-type-attribute-meta
         - tag-generic-attribute-value
     - match: (?i)(?=text/sass{{unquoted_attribute_break}}|'text/sass'|"text/sass")
       set:
         - style-sass
-        - tag-generic-attribute-meta
+        - tag-type-attribute-meta
         - tag-generic-attribute-value
     - match: (?i)(?=text/scss{{unquoted_attribute_break}}|'text/scss'|"text/scss")
       set:
         - style-scss
-        - tag-generic-attribute-meta
+        - tag-type-attribute-meta
         - tag-generic-attribute-value
     - match: (?i)(?=text/stylus{{unquoted_attribute_break}}|'text/stylus'|"text/stylus")
       set:
         - style-stylus
-        - tag-generic-attribute-meta
+        - tag-type-attribute-meta
         - tag-generic-attribute-value
     - match: (?=\S)
       set:
         - style-css
-        - tag-generic-attribute-meta
+        - tag-type-attribute-meta
         - tag-generic-attribute-value
 
   style-less:
@@ -421,6 +421,20 @@ contexts:
         2: comment.block.html punctuation.definition.comment.end.html
         3: source.stylus.embedded.html
         4: comment.block.html punctuation.definition.comment.end.html
+
+###[ HTML TAG ATTRIBUTES ]#####################################################
+
+  tag-lang-attribute-meta:
+    # required until ST4184 (PR #4061)
+    - meta_include_prototype: false
+    - meta_scope: meta.attribute-with-value.lang.html
+    - include: immediately-pop
+
+  tag-type-attribute-meta:
+    # required until ST4184 (PR #4061)
+    - meta_include_prototype: false
+    - meta_scope: meta.attribute-with-value.type.html
+    - include: immediately-pop
 
 ###[ SVELTE COMPONENTS ]#######################################################
 

--- a/Svelte.sublime-syntax
+++ b/Svelte.sublime-syntax
@@ -98,11 +98,6 @@ contexts:
         - script-livescript
         - tag-lang-attribute-meta
         - tag-generic-attribute-value
-    - match: (?i)(?=(?:js|javascript){{unquoted_attribute_break}}|'(?:js|javascript)'|"(?:js|javascript)")
-      set:
-        - script-javascript
-        - tag-lang-attribute-meta
-        - tag-generic-attribute-value
     - match: (?i)(?=(?:ts|typescript){{unquoted_attribute_break}}|'(?:ts|typescript)'|"(?:ts|typescript)")
       set:
         - script-typescript

--- a/Svelte.sublime-syntax
+++ b/Svelte.sublime-syntax
@@ -13,7 +13,7 @@ variables:
 
   # script mimetypes
   babel_mime_type: (?:(?:text|application)/babel)
-  coffeescript_mime_type: (?:(?:text|application)/coffeescript)
+  coffeescript_mime_type: (?:(?:text|application)/coffee(?:script)?)
   livescript_mime_type: (?:(?:text|application)/livescript)
   typescript_mime_type: (?:(?:text|application)/typescript)
 
@@ -88,7 +88,7 @@ contexts:
         - script-babel
         - tag-generic-attribute-meta
         - tag-generic-attribute-value
-    - match: (?i)(?=coffeescript{{unquoted_attribute_break}}|'coffeescript'|"coffeescript")
+    - match: (?i)(?=coffee(?:script)?{{unquoted_attribute_break}}|'coffee(?:script)?'|"coffee(?:script)?")
       set:
         - script-coffeescript
         - tag-generic-attribute-meta

--- a/tests/syntax_test_scope.svelte
+++ b/tests/syntax_test_scope.svelte
@@ -32,6 +32,48 @@
     }
 </script>
 
+<script lang="coffee">
+/*^^^^^^^^^^^^^^^^^^^^ meta.template.svelte meta.tag.script.begin.html */
+/*^^^^^ entity.name.tag.script.html */
+/*      ^^^^^^^^^^^^^ meta.attribute-with-value.lang.html */
+/*      ^^^^ entity.other.attribute-name.html */
+/*          ^ punctuation.separator.key-value.html */
+/*           ^^^^^^^^ meta.string.html string.quoted.double.html */
+/*           ^ punctuation.definition.string.begin.html */
+/*                  ^ punctuation.definition.string.end.html */
+/*                   ^ punctuation.definition.tag.end.html */
+
+/* <- source.coffee.embedded.html */
+</script>
+
+<script lang="coffeescript">
+/*^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.template.svelte meta.tag.script.begin.html */
+/*^^^^^ entity.name.tag.script.html */
+/*      ^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.lang.html */
+/*      ^^^^ entity.other.attribute-name.html */
+/*          ^ punctuation.separator.key-value.html */
+/*           ^^^^^^^^^^^^^^ meta.string.html string.quoted.double.html */
+/*           ^ punctuation.definition.string.begin.html */
+/*                        ^ punctuation.definition.string.end.html */
+/*                         ^ punctuation.definition.tag.end.html */
+
+/* <- source.coffee.embedded.html */
+</script>
+
+<script lang="livescript">
+/*^^^^^^^^^^^^^^^^^^^^^^^^ meta.template.svelte meta.tag.script.begin.html */
+/*^^^^^ entity.name.tag.script.html */
+/*      ^^^^^^^^^^^^^^^^^ meta.attribute-with-value.lang.html */
+/*      ^^^^ entity.other.attribute-name.html */
+/*          ^ punctuation.separator.key-value.html */
+/*           ^^^^^^^^^^^^ meta.string.html string.quoted.double.html */
+/*           ^ punctuation.definition.string.begin.html */
+/*                      ^ punctuation.definition.string.end.html */
+/*                       ^ punctuation.definition.tag.end.html */
+
+/* <- source.livescript.embedded.html */
+</script>
+
 ###[ STYLES ]##################################################################
 
 <style>
@@ -108,6 +150,20 @@
 /*               ^ punctuation.section.interpolation.end.scss */
     }
 /* ^^ source.scss.embedded.html meta.at-rule.mixin.scss meta.property-list.css meta.block.css */
+</style>
+
+<style lang="stylus">
+/*^^^^^^^^^^^^^^^^^^^ meta.template.svelte meta.tag.style.begin.html */
+/*^^^^ entity.name.tag.style.html */
+/*     ^^^^^^^^^^^^^ meta.attribute-with-value.lang.html */
+/*     ^^^^ entity.other.attribute-name.html */
+/*         ^ punctuation.separator.key-value.html */
+/*          ^^^^^^^^ meta.string.html string.quoted.double.html */
+/*          ^ punctuation.definition.string.begin.html */
+/*                 ^ punctuation.definition.string.end.html */
+/*                  ^ punctuation.definition.tag.end.html */
+
+/* <- source.stylus.embedded.html */
 </style>
 
 ###[ ATTRIBUTES ]##############################################################


### PR DESCRIPTION
This PR...

1. applies scope changes from https://github.com/sublimehq/Packages/pull/4061
2. adds completions for `lang=` and `type=` attribute values.
3. adds support for long `language=` attribute to align with recent core package changes.
4. adds support for short `lang="coffee"` as alternative for `lang="coffeescript"`.
5. creates dome dummy syntaxes to be able to test embedded syntaxes in script/style tags without actually cloning required syntax packages.