### PR TITLE
docs: correct removal guidance on lang/type compat contexts

### DIFF
--- a/Svelte.sublime-syntax
+++ b/Svelte.sublime-syntax
@@ -446,16 +446,20 @@ contexts:
       pop: 1
     - include: scope:source.css.embedded.svelte.single-quoted
       apply_prototype: true
+
 ###[ HTML TAG ATTRIBUTES ]#####################################################
 
   tag-lang-attribute-meta:
-    # required until ST4184 (PR #4061)
+    # Package-owned context: core HTML defines no `lang` attribute context
+    # (sublimehq/Packages#4061 added only the `type` context to core HTML).
+    # Referenced by the script and style lang deciders — do not remove.
     - meta_include_prototype: false
     - meta_scope: meta.attribute-with-value.lang.html
     - include: immediately-pop
 
   tag-type-attribute-meta:
-    # required until ST4184 (PR #4061)
+    # Required until the minimum supported default packages include
+    # sublimehq/Packages#4061 (first bundled in v4193).
     - meta_include_prototype: false
     - meta_scope: meta.attribute-with-value.type.html
     - include: immediately-pop


### PR DESCRIPTION
The comments on `tag-lang-attribute-meta` and `tag-type-attribute-meta` (from #40) claimed both were required only until ST4184 per sublimehq/Packages#4061. Two corrections:

- #4061 added only the `type` context to core HTML, and it first shipped in default packages **v4193**, not v4184 (verified against the tagged package sources).
- Core HTML defines no `lang` attribute context at any build — `tag-lang-attribute-meta` is package-owned and referenced by the script/style lang deciders, so it must not be removed.

Without this fix, a plausible future cleanup at "min build ≥ 4184" would delete a required context and break four decider references.

Also restores a blank line before the section header that was lost in the #40 merge conflict resolution.