### PR TITLE
test: add regression coverage from adversarial review probes

### DIFF
--- a/tests/syntax_test_scope.svelte
+++ b/tests/syntax_test_scope.svelte
@@ -581,3 +581,118 @@
 /*                            ^ meta.string.js string.quoted.double.js punctuation.definition.string.begin.js
 /*                             ^^^^^^^ meta.string.js meta.interpolation.js variable.language.dollar.js - string
 /*                                    ^ meta.string.js string.quoted.double.js punctuation.definition.string.end.js
+
+###[ INTERPOLATED STYLE ATTRIBUTES ]###########################################
+
+<div style="{obj}"></div>
+/*     ^ meta.attribute-with-value.style.html */
+/*             ^ meta.embedded.block.svelte source.js.embedded.svelte variable.other.readwrite.js */
+
+<div style="width: {fn({a: 1})}px"></div>
+/*                  ^ meta.embedded.block.svelte source.js.embedded.svelte meta.function-call.js */
+/*                      ^ meta.mapping.js meta.mapping.key.js */
+/*                           ^ meta.embedded.block.svelte source.js.embedded.svelte */
+/*                            ^ punctuation.section.embedded.end.svelte */
+
+<div style="color: {ok ? 'red' : 'blue'}"></div>
+/*                  ^ meta.embedded.block.svelte source.js.embedded.svelte variable.other.readwrite.js */
+/*                          ^ string.quoted.single.js */
+
+<div style='color: {ok ? "red" : "blue"}'></div>
+/*                  ^ meta.embedded.block.svelte source.js.embedded.svelte variable.other.readwrite.js */
+/*                          ^ string.quoted.double.js */
+
+<div style="background: url({src})"></div>
+/*                             ^ meta.embedded.block.svelte source.js.embedded.svelte variable.other.readwrite.js */
+
+<div style="content: '\'x\''"></div>
+/*                       ^ string.quoted.single.css */
+
+<div style='content: "\"x\""'></div>
+/*                       ^ string.quoted.double.css */
+
+<div style="/* c */ color: red"></div>
+/*            ^ comment.block.css */
+/*                    ^ support.type.property-name.css */
+
+<div style="--x: {v}; color: var(--x)"></div>
+/*            ^ entity.other.custom-property.css */
+/*                ^ meta.embedded.block.svelte source.js.embedded.svelte */
+/*                            ^ support.function.var.css */
+
+<div style="color: red !important; width: {w}px;"></div>
+/*                        ^ keyword.other.important.css */
+/*                                         ^ meta.embedded.block.svelte source.js.embedded.svelte */
+/*                                             ^ punctuation.terminator.rule.css */
+
+<div style="color: {color};
+width: {width}px"></div>
+/* <- meta.string.html meta.interpolation.html source.css.embedded.html */
+/*        ^ meta.embedded.block.svelte source.js.embedded.svelte */
+<p>{sentinel}</p>
+/* <- meta.template.svelte meta.tag */
+/*    ^ meta.embedded.block.svelte source.js.embedded.svelte */
+
+<div style:color={c}></div>
+/*     ^ support.function.svelte */
+/*        ^ punctuation.separator.svelte */
+/*                ^ meta.embedded.block.svelte source.js.embedded.svelte */
+
+###[ COMPONENT STRING ATTRIBUTES ]#############################################
+
+<Comp style="anything {x} here" />
+/*      ^ entity.other.attribute-name.html */
+/*             ^ meta.string.html - source.css.embedded.html */
+/*                     ^ meta.embedded.block.svelte source.js.embedded.svelte */
+
+<Comp onclick="not js" />
+/*      ^ entity.other.attribute-name.html - entity.other.attribute-name.event.html */
+/*               ^ meta.string.html - source.js.embedded.html */
+
+<div onclick="alert('ok')"></div>
+/*     ^ entity.other.attribute-name.event.html */
+/*              ^ source.js.embedded.html */
+
+###[ LANG / TYPE ATTRIBUTE DECIDERS ]##########################################
+
+<script lang=ts>
+let typed: number = 1;
+/* <- source.ts.embedded.html */
+</script>
+/* <- meta.tag.script.end.html punctuation.definition.tag.begin.html */
+
+<script LANG="TS">
+let typed: number = 1;
+/* <- source.ts.embedded.html */
+</script>
+/* <- meta.tag.script.end.html punctuation.definition.tag.begin.html */
+
+<script lang="">
+const emptyLang = true;
+/* <- source.js.embedded.html */
+</script>
+/* <- meta.tag.script.end.html punctuation.definition.tag.begin.html */
+
+<script lang="rust">
+const unknownLang = true;
+/* <- source.js.embedded.html */
+</script>
+/* <- meta.tag.script.end.html punctuation.definition.tag.begin.html */
+
+<script type=text/typescript>
+let typed: number = 1;
+/* <- source.ts.embedded.html */
+</script>
+/* <- meta.tag.script.end.html punctuation.definition.tag.begin.html */
+
+<style lang="unknown">
+a { color: red; }
+/* <- source.css.embedded.html */
+</style>
+/* <- meta.tag.style.end.html punctuation.definition.tag.begin.html */
+
+<style language="scss">
+$color: red;
+/* <- source.scss.embedded.html */
+</style>
+/* <- meta.tag.style.end.html punctuation.definition.tag.begin.html */

--- a/tests/syntax_test_scope.svx
+++ b/tests/syntax_test_scope.svx
@@ -174,3 +174,61 @@
 |^ punctuation.definition.tag.begin.html
 | ^^ entity.name.tag
 |   ^ punctuation.definition.tag.end.html
+
+```
+{#if x}
+|  ^ markup.raw.code-fence.markdown-gfm - meta.embedded.block.svelte
+<Component value={x} />
+| ^ markup.raw.code-fence.markdown-gfm - meta.tag.component.html
+|                ^ markup.raw.code-fence.markdown-gfm - meta.embedded.block.svelte
+{/if}
+|  ^ markup.raw.code-fence.markdown-gfm - meta.embedded.block.svelte
+```
+
+# Sentinel {sentinel01}
+|^^^^^^^^^^^^^^^^^^^^^^^ markup.heading.1.markdown
+|            ^ meta.embedded.block.svelte source.js.embedded.svelte
+
+`{notSvelte}`
+| ^ markup.raw.inline.markdown - meta.embedded.block.svelte
+
+<script>
+const inside = 1;
+|^ source.js.embedded.html
+</script>
+|^ meta.tag.script.end.html
+
+<style lang="scss">
+$color: red;
+|^ source.scss.embedded.html
+</style>
+|^ meta.tag.style.end.html
+
+# Sentinel {sentinel02}
+|^^^^^^^^^^^^^^^^^^^^^^^ markup.heading.1.markdown
+|            ^ meta.embedded.block.svelte source.js.embedded.svelte
+
+{@html expression}
+| ^ support.function.svelte
+|      ^ meta.embedded.block.svelte source.js.embedded.svelte
+
+{#await promise}
+| ^ meta.embedded.block.svelte source.js.embedded.svelte keyword.control.await.svelte
+{:then value}
+| ^ meta.embedded.block.svelte source.js.embedded.svelte keyword.control.flow.svelte
+{value}
+| ^ meta.embedded.block.svelte source.js.embedded.svelte
+{:catch error}
+| ^ meta.embedded.block.svelte source.js.embedded.svelte keyword.control.flow.svelte
+{/await}
+| ^ meta.embedded.block.svelte source.js.embedded.svelte keyword.control.await.end.svelte
+
+{#if unclosed}
+| ^ meta.embedded.block.svelte source.js.embedded.svelte keyword.control.conditional.if.svelte
+Markdown remains **bold** after the unclosed Svelte block.
+|^ meta.paragraph.markdown
+|                    ^ markup.bold.markdown
+
+# Sentinel {sentinel03}
+|^^^^^^^^^^^^^^^^^^^^^^^ markup.heading.1.markdown
+|            ^ meta.embedded.block.svelte source.js.embedded.svelte


### PR DESCRIPTION
Ports validated assertions from the adversarial review of #39/#40/#41 into the committed suite, converting one-time verification into permanent CI coverage:

**Interpolated style attributes (#39):** nested braces (`{fn({a: 1})}` including termination at the correct closing brace), quote-swapped ternaries, `url({src})`, escaped quotes in CSS strings, CSS comments, custom properties, `!important`/multi-declaration, multiline values, and the `style:` directive.

**Component string attributes (#39):** `style`/`onclick` on components stay plain string props (no CSS/JS embedding); native `onclick` keeps JS embedding.

**Lang/type deciders (#40):** unquoted values (`lang=ts`, `type=text/typescript`), casing (`LANG="TS"`), unknown/empty language fallbacks to JS/CSS, and the `language=` long form.

**MDSVEX invariants (#41):** Svelte stays raw inside fenced and inline code (with positive raw-scope assertions on a neutral fence, so future `svelte`-fence embedding stays possible), script/style embedding in `.svx`, `{@html}` expression embedding, `{#await}` chains, and unclosed-block containment.

All assertions validated locally against ST 4143 and 4207.