### PR TITLE
fix: stop scoping legacy special variables inside string literals

### DIFF
--- a/Embeddings/JavaScript (for Svelte).sublime-syntax
+++ b/Embeddings/JavaScript (for Svelte).sublime-syntax
@@ -20,15 +20,3 @@ contexts:
       captures:
         1: punctuation.definition.variable.js
       pop: 1
-
-  string-content:
-    - meta_prepend: true
-    - match: (\$\$)(?:restProps|props|slots)\b
-      scope: meta.interpolation.js variable.language.dollar.js
-      captures:
-        1: punctuation.definition.variable.js
-      push:
-        - clear_scopes: 1
-        - meta_include_prototype: false
-        - match: ''
-          pop: 1

--- a/tests/syntax_test_scope.svelte
+++ b/tests/syntax_test_scope.svelte
@@ -573,13 +573,13 @@
     { "$$slots" "$$restProps" "$$props" }
 /*  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.block.svelte
 /*    ^ meta.string.js string.quoted.double.js punctuation.definition.string.begin.js
-/*     ^^^^^^^ meta.string.js meta.interpolation.js variable.language.dollar.js - string
+/*     ^^^^^^^ meta.string.js string.quoted.double.js - variable
 /*            ^ meta.string.js string.quoted.double.js punctuation.definition.string.end.js
 /*              ^ meta.string.js string.quoted.double.js punctuation.definition.string.begin.js
-/*               ^^^^^^^^^^^ meta.string.js meta.interpolation.js variable.language.dollar.js - string
+/*               ^^^^^^^^^^^ meta.string.js string.quoted.double.js - variable
 /*                          ^ meta.string.js string.quoted.double.js punctuation.definition.string.end.js
 /*                            ^ meta.string.js string.quoted.double.js punctuation.definition.string.begin.js
-/*                             ^^^^^^^ meta.string.js meta.interpolation.js variable.language.dollar.js - string
+/*                             ^^^^^^^ meta.string.js string.quoted.double.js - variable
 /*                                    ^ meta.string.js string.quoted.double.js punctuation.definition.string.end.js
 
 ###[ INTERPOLATED STYLE ATTRIBUTES ]###########################################


### PR DESCRIPTION
Inside a JavaScript string, text like `"$$props"` is ordinary string content, not a reference to the legacy `$$props` variable. This removes the `string-content` override that stripped string scope from it. Bare identifiers keep their `variable.language.dollar.js` scope.

Addresses finding 6 of the syntax audit (legacy special variables incorrectly interpolated inside string literals).

Syntax tests updated and passing on ST builds 4143 and latest.