### PR TITLE
feat: highlight the TypeScript generics attribute on script tags

### DIFF
--- a/Svelte.sublime-syntax
+++ b/Svelte.sublime-syntax
@@ -21,6 +21,7 @@ variables:
   svelte_attribute_name: '[[:alnum:]_-]+'
   svelte_component_name: '[[:upper:]][[:alnum:]_]*'
   svelte_tag_name: '[[:alpha:]][[:alnum:]_]*'
+  svelte_ts_identifier: '[_$\p{L}\p{Nl}][_$\p{L}\p{Nl}\p{Mn}\p{Mc}\p{Nd}\p{Pc}\x{200C}\x{200D}]*'
 
 contexts:
 
@@ -63,6 +64,7 @@ contexts:
   script-common:
     - meta_prepend: true
     - include: script-lang-attribute
+    - include: script-generics-attribute
 
   script-lang-attribute:
     - match: (?i:lang(?:uage)?){{attribute_name_break}}
@@ -108,6 +110,67 @@ contexts:
         - script-javascript
         - tag-lang-attribute-meta
         - tag-generic-attribute-value
+
+  script-generics-attribute:
+    # https://svelte.dev/docs/svelte/typescript#Generic-$props
+    # Pushed (not set) so the surrounding script context survives and a
+    # lang attribute may appear on either side of it.
+    - match: (?i:generics){{attribute_name_break}}
+      scope: meta.attribute-with-value.generics.svelte entity.other.attribute-name.html
+      push:
+        - script-generics-attribute-meta
+        - script-generics-attribute-assignment
+
+  script-generics-attribute-meta:
+    - meta_include_prototype: false
+    - meta_scope: meta.attribute-with-value.generics.svelte
+    - include: immediately-pop
+
+  script-generics-attribute-assignment:
+    - meta_include_prototype: false
+    - match: =
+      scope: punctuation.separator.key-value.html
+      set: script-generics-attribute-value
+    - include: else-pop
+
+  script-generics-attribute-value:
+    - meta_include_prototype: false
+    - match: \"
+      scope: meta.string.html string.quoted.double.html punctuation.definition.string.begin.html
+      set: script-generics-attribute-double-quoted-value
+    - match: \'
+      scope: meta.string.html string.quoted.single.html punctuation.definition.string.begin.html
+      set: script-generics-attribute-single-quoted-value
+    - include: else-pop
+
+  script-generics-attribute-double-quoted-value:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.html source.ts.embedded.html
+    - match: \"
+      scope: meta.string.html string.quoted.double.html punctuation.definition.string.end.html
+      pop: 1
+    - include: script-generics-parameters
+
+  script-generics-attribute-single-quoted-value:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.html source.ts.embedded.html
+    - match: \'
+      scope: meta.string.html string.quoted.single.html punctuation.definition.string.end.html
+      pop: 1
+    - include: script-generics-parameters
+
+  script-generics-parameters:
+    # the content of a TypeScript type parameter list, without the
+    # angle brackets: Item extends { text: string } = Default, ...
+    - match: ','
+      scope: punctuation.separator.comma.js
+    - match: const(?![_$\p{L}\p{Nl}\p{Mn}\p{Mc}\p{Nd}\p{Pc}\x{200C}\x{200D}])
+      scope: storage.modifier.const.js
+    - match: '{{svelte_ts_identifier}}'
+      scope: variable.parameter.type.js
+      push:
+        - scope:source.ts#ts-type-parameter-default
+        - scope:source.ts#ts-type-parameter-constraint
 
   script-type-decider:
     - meta_prepend: true

--- a/tests/syntax_test_scope.svelte
+++ b/tests/syntax_test_scope.svelte
@@ -696,3 +696,58 @@ $color: red;
 /* <- source.scss.embedded.html */
 </style>
 /* <- meta.tag.style.end.html punctuation.definition.tag.begin.html */
+
+###[ GENERICS ATTRIBUTE ]######################################################
+
+<script lang="ts" generics="Item extends { text: string }, Extra = string">
+/*                ^^^^^^^^ meta.attribute-with-value.generics.svelte entity.other.attribute-name.html
+/*                        ^ punctuation.separator.key-value.html
+/*                         ^ meta.string.html punctuation.definition.string.begin.html
+/*                          ^^^^ source.ts.embedded.html variable.parameter.type.js
+/*                               ^^^^^^^ storage.modifier.extends.js
+/*                                       ^ punctuation.section.mapping.begin.js
+/*                                         ^^^^ variable.other.readwrite.js
+/*                                             ^ punctuation.separator.type.js
+/*                                               ^^^^^^ support.type.primitive.string.js
+/*                                                      ^ punctuation.section.mapping.end.js
+/*                                                       ^ punctuation.separator.comma.js
+/*                                                         ^^^^^ variable.parameter.type.js
+/*                                                               ^ keyword.operator.assignment.js
+/*                                                                 ^^^^^^ support.type.primitive.string.js
+/*                                                                       ^ punctuation.definition.string.end.html - source.ts
+/*                                                                        ^ punctuation.definition.tag.end.html
+    let first: Item;
+/* <- source.ts.embedded.html
+</script>
+
+<script generics="T" lang="ts">
+/*      ^^^^^^^^ meta.attribute-with-value.generics.svelte entity.other.attribute-name.html
+/*                ^ variable.parameter.type.js
+/*                 ^ punctuation.definition.string.end.html
+/*                   ^^^^ entity.other.attribute-name.html
+let generic: T;
+/* <- source.ts.embedded.html
+</script>
+
+<script lang="ts" generics='K extends string = "id"'>
+/*                          ^ variable.parameter.type.js
+/*                            ^^^^^^^ storage.modifier.extends.js
+/*                                    ^^^^^^ support.type.primitive.string.js
+/*                                           ^ keyword.operator.assignment.js
+/*                                             ^^^^ meta.string.js string.quoted.double.js
+/*                                                 ^ punctuation.definition.string.end.html - source.ts
+/*                                                  ^ punctuation.definition.tag.end.html
+let key: K;
+/* <- source.ts.embedded.html
+</script>
+
+<script lang="ts" generics="const T extends readonly string[]">
+/*                          ^^^^^ storage.modifier.const.js
+/*                                ^ variable.parameter.type.js
+/*                                  ^^^^^^^ storage.modifier.extends.js
+/*                                          ^^^^^^^^ storage.modifier
+/*                                                   ^^^^^^ support.type.primitive.string.js
+/*                                                           ^ punctuation.definition.string.end.html - source.ts
+let c: T;
+/* <- source.ts.embedded.html
+</script>


### PR DESCRIPTION
The [`generics` attribute](https://svelte.dev/docs/svelte/typescript#Generic-$props) holds a TypeScript type parameter list. Previously it was only an HTML string; now the quoted value is parsed as TypeScript: parameter names, `const` modifiers, `extends` constraints, and defaults, reusing the default TS package's type-expression contexts (verified present in ST 4143 through latest).

The attribute is pushed rather than set, so it composes with a `lang` attribute on either side, and quote termination survives braces (`generics="Item extends { text: string }"`) and string-literal type defaults.

Addresses finding 4 of the syntax audit. Includes a review fix from gpt-5.6: `const` type parameters (`generics="const T extends readonly string[]"`) scope as a modifier, not a parameter name.

New syntax tests pass on ST builds 4143 and latest.