### PR TITLE
feat: parse template expressions as TypeScript

### DIFF
--- a/Embeddings/JavaScript (for Svelte).sublime-syntax
+++ b/Embeddings/JavaScript (for Svelte).sublime-syntax
@@ -4,7 +4,7 @@ scope: source.js.embedded.svelte
 version: 2
 hidden: true
 
-extends: Packages/JavaScript/JavaScript.sublime-syntax
+extends: Packages/JavaScript/TypeScript.sublime-syntax
 
 contexts:
 
@@ -12,6 +12,39 @@ contexts:
   expressions:
     - match: (?=\S)
       push: [ expression-end, expression-begin ]
+
+  # each-block source expressions must stop at the block's `as` keyword,
+  # which TypeScript would otherwise consume as a type assertion; only the
+  # last `as` before the closing brace is the block's own, so earlier ones
+  # keep their assertion meaning: {#each items as Item[] as item}
+  svelte-each-expression:
+    - match: (?=\S)
+      set: [ svelte-each-expression-end, expression-begin ]
+
+  svelte-each-expression-end:
+    - match: (?=as{{identifier_break}}(?![^{}]*\sas{{identifier_break}}))
+      pop: 1
+    # mirrors ts-type-assertion, but with a guarded type-expression-end so
+    # the block's own `as` is not consumed as a chained assertion
+    - match: as{{identifier_break}}
+      scope: keyword.operator.type.js
+      push:
+        - match: const{{identifier_break}}
+          scope: storage.modifier.const.js
+          pop: 1
+        - match: (?=\S)
+          set:
+            - ts-type-meta
+            - svelte-each-type-expression-end
+            - ts-type-expression-end-no-line-terminator
+            - ts-type-expression-begin
+    - include: expression-end
+
+  svelte-each-type-expression-end:
+    # pops this context, ts-type-meta and svelte-each-expression-end
+    - match: (?=as{{identifier_break}}(?![^{}]*\sas{{identifier_break}}))
+      pop: 3
+    - include: ts-type-expression-end
 
   literal-variable:
     - meta_prepend: true

--- a/Svelte.sublime-syntax
+++ b/Svelte.sublime-syntax
@@ -671,7 +671,7 @@ contexts:
       set:
         - svelte-embedded-index
         - svelte-embedded-as
-        - scope:source.js.embedded.svelte#expression
+        - scope:source.js.embedded.svelte#svelte-each-expression
     - match: /each\b
       scope: keyword.control.loop.end.svelte
       pop: 1

--- a/tests/syntax_test_scope.svelte
+++ b/tests/syntax_test_scope.svelte
@@ -751,3 +751,63 @@ let key: K;
 let c: T;
 /* <- source.ts.embedded.html
 </script>
+###[ TYPESCRIPT EXPRESSIONS ]##################################################
+
+    {value as string}
+/*  ^^^^^^^^^^^^^^^^^ meta.embedded.block.svelte
+/*   ^^^^^ source.js.embedded.svelte variable.other.readwrite.js
+/*         ^^ keyword.operator.type.js
+/*            ^^^^^^ support.type.primitive.string.js
+/*                  ^ punctuation.section.embedded.end.svelte
+
+    {value as string}<em>contained</em>
+/*                   ^^^^ meta.tag - meta.embedded.block.svelte
+
+    {(e: Event) => handler(e)}
+/*  ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.block.svelte
+/*   ^ punctuation.section.group.begin.js
+/*    ^ variable.parameter.function.js
+/*     ^ punctuation.separator.type.js
+/*       ^^^^^ support.class.js
+/*            ^ punctuation.section.group.end.js
+/*              ^^ keyword.declaration.function.arrow.js
+/*                 ^^^^^^^ variable.function.js
+/*                         ^ variable.other.readwrite.js
+/*                           ^ punctuation.section.embedded.end.svelte
+
+    {fn<Result>(value)}
+/*   ^^ variable.function.js
+/*     ^ punctuation.definition.generic.begin.js
+/*      ^^^^^^ support.class.js
+/*            ^ punctuation.definition.generic.end.js
+/*             ^ punctuation.section.group.begin.js
+/*              ^^^^^ variable.other.readwrite.js
+/*                   ^ punctuation.section.group.end.js
+
+    {#each (items as Item[]) as item, index (item.id)}<span>{item}</span>{/each}
+/*  ^ punctuation.section.embedded.begin.svelte
+/*   ^^^^^ keyword.control.loop.each.svelte
+/*         ^ punctuation.section.group.begin.js
+/*          ^^^^^ variable.other.readwrite.js
+/*                ^^ keyword.operator.type.js
+/*                   ^^^^ support.class.js
+/*                       ^^ meta.type.js
+/*                         ^ punctuation.section.group.end.js
+/*                           ^^ keyword.operator.assignment.as.svelte
+/*                              ^^^^ variable.other.readwrite.js
+/*                                  ^ punctuation.separator.comma.svelte
+/*                                    ^^^^^ variable.other.readwrite.js
+/*                                          ^ punctuation.section.group.begin.js
+/*                                           ^^^^ variable.other.readwrite.js
+/*                                               ^ punctuation.accessor.js
+/*                                                   ^ punctuation.section.embedded.end.svelte
+
+    {#each items as Item[] as item}<span>{item}</span>{/each}
+/*   ^^^^^ keyword.control.loop.each.svelte
+/*         ^^^^^ variable.other.readwrite.js
+/*               ^^ keyword.operator.type.js
+/*                  ^^^^ support.class.js
+/*                      ^^ meta.type.js
+/*                         ^^ keyword.operator.assignment.as.svelte
+/*                            ^^^^ variable.other.readwrite.js
+/*                                ^ punctuation.section.embedded.end.svelte

--- a/tests/syntax_test_scope.svx
+++ b/tests/syntax_test_scope.svx
@@ -263,3 +263,8 @@ Markdown remains **bold** after the unclosed Svelte block.
 # Sentinel {sentinel03}
 |^^^^^^^^^^^^^^^^^^^^^^^ markup.heading.1.markdown
 |            ^ meta.embedded.block.svelte source.js.embedded.svelte
+
+{value as string}
+|^^^^^ variable.other.readwrite.js
+|      ^^ keyword.operator.type.js
+|         ^^^^^^ support.type.primitive.string.js


### PR DESCRIPTION
Svelte permits TypeScript in template expressions when the component uses TS. Sublime syntaxes cannot switch template parsing based on the script tag's `lang` attribute (context state does not persist across the file), so the expression embedding now extends `TypeScript.sublime-syntax` instead of JavaScript. TS is a superset and the default TS package hard-codes `.js` scopes for shared constructs, so plain-JS expressions scope identically and the `source.js.embedded.svelte` contract is unchanged — verified by the existing test suite passing untouched.

TypeScript would consume an each block's `as` keyword as a type assertion, so each-block source expressions go through a dedicated context that treats only the last `as` before the closing brace as the block's own (matching the Svelte parser, which accepts `{#each items as Item[] as item}` and binds `item`). Parenthesized assertions also work: `{#each (items as Item[]) as item}`.

Addresses finding 1 of the syntax audit. Includes a review fix from gpt-5.6: unparenthesized top-level assertions in each sources keep their assertion meaning.

New tests cover typed arrow params, `as` casts, generic calls, and both each-assertion forms, passing on ST builds 4143 and latest.