### PR TITLE
feat: support render tags, attachments, declaration tags, and snippet declarations

### DIFF
--- a/Embeddings/JavaScript (for Svelte).sublime-syntax
+++ b/Embeddings/JavaScript (for Svelte).sublime-syntax
@@ -46,6 +46,23 @@ contexts:
       pop: 3
     - include: ts-type-expression-end
 
+  # declaration tags: {let sum = a + b}, {const {width, height} = box}
+  svelte-declaration:
+    - match: (?:const|let){{identifier_break}}
+      scope: keyword.declaration.js
+      set:
+        - variable-binding-list-top
+        - variable-binding-top
+    - include: else-pop
+
+  # binding + initializer of {@const ...} special tags
+  svelte-declaration-binding:
+    - meta_include_prototype: false
+    - match: ''
+      set:
+        - variable-binding-list-top
+        - variable-binding-top
+
   literal-variable:
     - meta_prepend: true
     - match: (\$\$)(?:restProps|props|slots)\b

--- a/Svelte.sublime-syntax
+++ b/Svelte.sublime-syntax
@@ -649,9 +649,15 @@ contexts:
 
   svelte-embedded-begin:
     - meta_include_prototype: false
-    - match: \@(?:html|debug|const)\b
+    - match: \@(?:html|debug|render)\b
       scope: support.function.svelte
       pop: 1
+    - match: \@const\b
+      scope: support.function.svelte
+      set: scope:source.js.embedded.svelte#svelte-declaration-binding
+    # declaration tags
+    - match: (?=(?:let|const)\b)
+      set: scope:source.js.embedded.svelte#svelte-declaration
     # conditionals
     - match: \#if\b
       scope: keyword.control.conditional.if.svelte
@@ -678,10 +684,7 @@ contexts:
     # snippets
     - match: \#snippet\b
       scope: keyword.control.snippet.begin.svelte
-      set:
-        - svelte-embedded-index
-        - svelte-embedded-as
-        - scope:source.js.embedded.svelte#expression
+      set: svelte-snippet-name
     - match: /snippet\b
       scope: keyword.control.snippet.end.svelte
       pop: 1
@@ -736,6 +739,29 @@ contexts:
       pop: 1
     - include: else-pop
 
+  svelte-snippet-name:
+    - meta_include_prototype: false
+    # no \b boundaries: they fail before/after names starting or ending
+    # with `$`, which is a valid identifier character but not a word one
+    - match: '[_$\p{L}\p{Nl}][_$\p{L}\p{Nl}\p{Mn}\p{Mc}\p{Nd}\p{Pc}\x{200C}\x{200D}]*'
+      scope: entity.name.function.svelte
+      set: svelte-snippet-parameters
+    - include: else-pop
+
+  svelte-snippet-parameters:
+    - meta_include_prototype: false
+    - match: (?=<)
+      push: scope:source.js.embedded.svelte#ts-type-parameter-list
+    - match: \(
+      scope: punctuation.section.group.begin.js
+      set:
+        - meta_scope: meta.function.parameters.js
+        - match: \)
+          scope: punctuation.section.group.end.js
+          pop: 1
+        - include: scope:source.js.embedded.svelte#function-parameter-binding-list
+    - include: else-pop
+
   svelte-embedded-body:
     - meta_scope: meta.embedded.block.svelte
     - meta_content_scope: source.js.embedded.svelte
@@ -749,7 +775,16 @@ contexts:
   svelte-interpolations:
     - match: \{
       scope: punctuation.section.embedded.begin.svelte
-      push: svelte-interpolation-body
+      push:
+        - svelte-interpolation-body
+        - svelte-interpolation-begin
+
+  svelte-interpolation-begin:
+    - meta_include_prototype: false
+    - match: \@attach\b
+      scope: support.function.svelte
+      pop: 1
+    - include: else-pop
 
   svelte-interpolation-body:
     - clear_scopes: 1 # clear string scope

--- a/tests/syntax_test_scope.svelte
+++ b/tests/syntax_test_scope.svelte
@@ -811,3 +811,128 @@ let c: T;
 /*                         ^^ keyword.operator.assignment.as.svelte
 /*                            ^^^^ variable.other.readwrite.js
 /*                                ^ punctuation.section.embedded.end.svelte
+
+###[ RENDER TAGS ]#############################################################
+
+    {@render row(item)}
+/*  ^^^^^^^^^^^^^^^^^^^ meta.embedded.block.svelte
+/*  ^ punctuation.section.embedded.begin.svelte
+/*   ^^^^^^^ support.function.svelte
+/*           ^^^ variable.function.js
+/*              ^ punctuation.section.group.begin.js
+/*               ^^^^ variable.other.readwrite.js
+/*                   ^ punctuation.section.group.end.js
+/*                    ^ punctuation.section.embedded.end.svelte
+
+    {@render maybe?.()}
+/*   ^^^^^^^ support.function.svelte
+/*           ^^^^^ variable.function.js
+/*                ^^ punctuation.accessor
+/*                    ^ punctuation.section.embedded.end.svelte
+
+###[ ATTACHMENTS ]#############################################################
+
+<div {@attach tooltip(content)}></div>
+/*   ^ punctuation.section.embedded.begin.svelte
+/*    ^^^^^^^ support.function.svelte
+/*            ^^^^^^^ variable.function.js
+/*                    ^^^^^^^ variable.other.readwrite.js
+/*                            ^ punctuation.section.embedded.end.svelte
+
+<Comp {@attach fn} />
+/*     ^^^^^^^ support.function.svelte
+/*             ^^ variable.other.readwrite.js
+/*               ^ punctuation.section.embedded.end.svelte
+
+###[ DECLARATION TAGS ]########################################################
+
+    {let sum = a + b}
+/*  ^^^^^^^^^^^^^^^^^ meta.embedded.block.svelte
+/*   ^^^ keyword.declaration.js
+/*       ^^^ meta.binding.name.js variable.other.readwrite.js
+/*           ^ keyword.operator.assignment.js
+/*             ^ variable.other.readwrite.js
+/*               ^ keyword.operator.arithmetic.js
+/*                  ^ punctuation.section.embedded.end.svelte
+
+    {const {width, height} = box}
+/*   ^^^^^ keyword.declaration.js
+/*         ^ punctuation.section.mapping.begin.js
+/*          ^^^^^ variable.other.readwrite.js
+/*               ^ punctuation.separator.comma.js
+/*                 ^^^^^^ variable.other.readwrite.js
+/*                       ^ punctuation.section.mapping.end.js
+/*                         ^ keyword.operator.assignment.js
+/*                           ^^^ variable.other.readwrite.js
+/*                              ^ punctuation.section.embedded.end.svelte
+
+    {const area: number = width * height}
+/*   ^^^^^ keyword.declaration.js
+/*         ^^^^ meta.binding.name.js variable.other.readwrite.js
+/*             ^ punctuation.separator.type.js
+/*               ^^^^^^ support.type.primitive.number.js
+/*                      ^ keyword.operator.assignment.js
+/*                                      ^ punctuation.section.embedded.end.svelte
+
+    {@const {a, b} = obj}
+/*   ^^^^^^ support.function.svelte
+/*          ^ punctuation.section.mapping.begin.js
+/*           ^ variable.other.readwrite.js
+/*                 ^ keyword.operator.assignment.js
+/*                   ^^^ variable.other.readwrite.js
+/*                      ^ punctuation.section.embedded.end.svelte
+
+###[ SNIPPETS ]################################################################
+
+    {#snippet figure(image)}
+/*  ^ punctuation.section.embedded.begin.svelte
+/*   ^^^^^^^^ keyword.control.snippet.begin.svelte
+/*            ^^^^^^ entity.name.function.svelte
+/*                  ^ punctuation.section.group.begin.js
+/*                   ^^^^^ meta.function.parameters.js variable.parameter.function.js
+/*                        ^ punctuation.section.group.end.js
+/*                         ^ punctuation.section.embedded.end.svelte
+        <figure>{@render nested()}</figure>
+/*      ^^^^^^^^ meta.tag
+/*               ^^^^^^^ support.function.svelte
+    {/snippet}
+/*  ^ punctuation.section.embedded.begin.svelte
+/*   ^^^^^^^^ keyword.control.snippet.end.svelte
+/*           ^ punctuation.section.embedded.end.svelte
+
+    {#snippet row(item: Item, index: number = 0)}
+/*            ^^^ entity.name.function.svelte
+/*                ^^^^ variable.parameter.function.js
+/*                    ^ punctuation.separator.type.js
+/*                      ^^^^ support.class.js
+/*                          ^ punctuation.separator.parameter.function.js
+/*                            ^^^^^ variable.parameter.function.js
+/*                                 ^ punctuation.separator.type.js
+/*                                   ^^^^^^ support.type.primitive.number.js
+/*                                          ^ keyword.operator.assignment.js
+/*                                            ^ constant.numeric
+/*                                             ^ punctuation.section.group.end.js
+/*                                              ^ punctuation.section.embedded.end.svelte
+    {/snippet}
+
+    {#snippet $row(item)}
+/*            ^^^^ entity.name.function.svelte
+/*                ^ punctuation.section.group.begin.js
+/*                 ^^^^ variable.parameter.function.js
+/*                     ^ punctuation.section.group.end.js
+    {/snippet}
+
+    {#snippet pair<T>(a: T, b: T)}
+/*            ^^^^ entity.name.function.svelte
+/*                ^ punctuation.definition.generic.begin.js
+/*                 ^ variable.parameter
+/*                  ^ punctuation.definition.generic.end.js
+/*                   ^ punctuation.section.group.begin.js
+/*                    ^ variable.parameter.function.js
+/*                     ^ punctuation.separator.type.js
+/*                       ^ support.class.js
+/*                        ^ punctuation.separator.parameter.function.js
+/*                          ^ variable.parameter.function.js
+/*                              ^ punctuation.section.group.end.js
+/*                               ^ punctuation.section.embedded.end.svelte
+    {/snippet}

--- a/tests/syntax_test_scope.svx
+++ b/tests/syntax_test_scope.svx
@@ -268,3 +268,7 @@ Markdown remains **bold** after the unclosed Svelte block.
 |^^^^^ variable.other.readwrite.js
 |      ^^ keyword.operator.type.js
 |         ^^^^^^ support.type.primitive.string.js
+
+{@render row(item)}
+|^^^^^^^ support.function.svelte
+|        ^^^ variable.function.js


### PR DESCRIPTION
Adds highlighting for the remaining modern Svelte 5 template syntax (stacked on #48 for TypeScript-aware expression parsing):

- `{@render ...}` is recognized as a special tag; the call expression after it parses normally, including optional chaining.
- `{@attach ...}` works in attribute position on elements and components, where brace attributes enter the interpolation path that previously bypassed special-tag handling.
- `{let ...}` / `{const ...}` declaration tags (Svelte 5.56) parse as real declarations: keyword, binding patterns (destructuring, TS annotations), and initializers. `{@const ...}` now shares the same binding contexts, improving destructuring.
- `{#snippet name(params)}` scopes the snippet name as `entity.name.function.svelte` and parses parameters as function parameters, including TS annotations, defaults, and generic type parameter lists (`{#snippet pair<T>(a: T, b: T)}`).

Addresses findings 2, 3, and 5 of the syntax audit. Includes review fixes from gpt-5.6: dollar-prefixed snippet names (`{#snippet $row(...)}`) and generic snippet signatures, both verified valid against the Svelte compiler.

All referenced default-package contexts exist in ST 4143 through latest; tests pass on both.